### PR TITLE
Add UART as alternative transport to HID

### DIFF
--- a/Software/Driver/resources/settings/default-dev.vrsettings
+++ b/Software/Driver/resources/settings/default-dev.vrsettings
@@ -4,7 +4,10 @@
 		"HID_PID" : 32822,
 		"PSMSTrackerFrequency" : 75,
 		"ControllerSmoothingK" : 75.0,
-		"HMDSmoothingK" : 40.0
+		"HMDSmoothingK" : 40.0,
+		"TransportMode" : "HID",
+		"UART_Port" : "COM4",
+		"UART_Baudrate" : 230400
    },
    "Display" : {
 		"Stereo" : false,

--- a/Software/Driver/resources/settings/default.vrsettings
+++ b/Software/Driver/resources/settings/default.vrsettings
@@ -4,7 +4,10 @@
 		"HID_PID" : 32822,
 		"PSMSTrackerFrequency" : 120,
 		"ControllerSmoothingK" : 100.0,
-		"HMDSmoothingK" : 75.0
+		"HMDSmoothingK" : 75.0,
+		"TransportMode" : "HID",
+		"UART_Port" : "COM4",
+		"UART_Baudrate" : 230400
    },
    "Display" : {
 		"Stereo" : true,

--- a/Software/Driver/src/samples/driver_HadesVR/driver_HadesVR.vcxproj
+++ b/Software/Driver/src/samples/driver_HadesVR/driver_HadesVR.vcxproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -64,6 +64,10 @@
     <ClInclude Include="include\filters\V3Kalman.h" />
     <ClInclude Include="include\HandTracking.h" />
     <ClInclude Include="include\settingsAPIKeys.h" />
+    <ClInclude Include="include\DataTransport.hpp" />
+    <ClInclude Include="include\HIDTransport.hpp" />
+    <ClInclude Include="include\UARTTransport.hpp" />
+    <ClInclude Include="include\ringbuffer.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\dataHandler.cpp" />
@@ -74,6 +78,9 @@
     <ClCompile Include="src\filters\MadgwickOrientation.cpp" />
     <ClCompile Include="src\filters\V3Kalman.cpp" />
     <ClCompile Include="src\HandTracking.cpp" />
+    <ClCompile Include="src\HIDTransport.cpp" />
+    <ClCompile Include="src\ringbuffer.c" />
+    <ClCompile Include="src\UARTTransport.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Software/Driver/src/samples/driver_HadesVR/driver_HadesVR.vcxproj
+++ b/Software/Driver/src/samples/driver_HadesVR/driver_HadesVR.vcxproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Software/Driver/src/samples/driver_HadesVR/driver_HadesVR.vcxproj.filters
+++ b/Software/Driver/src/samples/driver_HadesVR/driver_HadesVR.vcxproj.filters
@@ -13,6 +13,9 @@
       <Filter>Filters</Filter>
     </ClCompile>
     <ClCompile Include="src\dataHandler_IMU.cpp" />
+    <ClCompile Include="src\HIDTransport.cpp" />
+    <ClCompile Include="src\UARTTransport.cpp" />
+    <ClCompile Include="src\ringbuffer.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\dataHandler.h" />
@@ -25,6 +28,10 @@
     <ClInclude Include="include\filters\V3Kalman.h">
       <Filter>Filters</Filter>
     </ClInclude>
+    <ClInclude Include="include\DataTransport.hpp" />
+    <ClInclude Include="include\HIDTransport.hpp" />
+    <ClInclude Include="include\UARTTransport.hpp" />
+    <ClInclude Include="include\ringbuffer.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Filters">

--- a/Software/Driver/src/samples/driver_HadesVR/include/DataTransport.hpp
+++ b/Software/Driver/src/samples/driver_HadesVR/include/DataTransport.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifndef _DATA_TRANSPORT_H_
+#define _DATA_TRANSPORT_H_
+
+#include <inttypes.h>
+
+class DataTransport {
+public:
+	virtual ~DataTransport() {}
+
+	virtual int Start() = 0;
+	virtual void Stop() = 0;
+
+	virtual bool IsConnected() = 0;
+	virtual int ReadPacket(uint8_t* buffer, size_t length) = 0;
+};
+
+#endif /* _DATA_TRANSPORT_H */

--- a/Software/Driver/src/samples/driver_HadesVR/include/HIDTransport.hpp
+++ b/Software/Driver/src/samples/driver_HadesVR/include/HIDTransport.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#ifndef _HID_TRANSPORT_H_
+#define _HID_TRANSPORT_H_
+
+#include "DataTransport.hpp"
+#include "hidapi/hidapi.h"
+
+class HIDTransport : public DataTransport {
+	// Inherited via DataTransport
+	virtual int Start() override;
+	virtual void Stop() override;
+	virtual bool IsConnected() override;
+	virtual int ReadPacket(uint8_t* buffer, size_t length) override;
+
+private:
+	hid_device* hHID;
+	bool HIDInit = false;
+	bool HIDConnected = false;
+};
+
+#endif

--- a/Software/Driver/src/samples/driver_HadesVR/include/HIDTransport.hpp
+++ b/Software/Driver/src/samples/driver_HadesVR/include/HIDTransport.hpp
@@ -8,10 +8,10 @@
 
 class HIDTransport : public DataTransport {
 	// Inherited via DataTransport
-	virtual int Start() override;
-	virtual void Stop() override;
-	virtual bool IsConnected() override;
-	virtual int ReadPacket(uint8_t* buffer, size_t length) override;
+	int Start() override;
+	void Stop() override;
+	bool IsConnected() override;
+	int ReadPacket(uint8_t* buffer, size_t length) override;
 
 private:
 	hid_device* hHID;

--- a/Software/Driver/src/samples/driver_HadesVR/include/UARTTransport.hpp
+++ b/Software/Driver/src/samples/driver_HadesVR/include/UARTTransport.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#ifndef _UART_TRANSPORT_H_
+#define _UART_TRANSPORT_H_
+
+#include "DataTransport.hpp"
+#include "ringbuffer.h"
+
+#define UART_BUFFER_SIZE (RING_BUFFER_SIZE)
+
+class UARTTransport : public DataTransport {
+public:
+	UARTTransport();
+
+	// Inherited via DataTransport
+	virtual int Start() override;
+	virtual void Stop() override;
+	virtual bool IsConnected() override;
+	virtual int ReadPacket(uint8_t* buffer, size_t length) override;
+
+private:
+	bool connected;
+	ring_buffer_t ringbuffer;
+	uint8_t lastSeqno;
+	bool hasReceivedFirstFrame;
+
+	HANDLE hSerial;
+	DCB dcbSerialParams = { 0 };
+	COMMTIMEOUTS timeouts = { 0 };
+};
+
+#endif /* _UART_TRANSPORT_H_ */

--- a/Software/Driver/src/samples/driver_HadesVR/include/UARTTransport.hpp
+++ b/Software/Driver/src/samples/driver_HadesVR/include/UARTTransport.hpp
@@ -13,10 +13,10 @@ public:
 	UARTTransport();
 
 	// Inherited via DataTransport
-	virtual int Start() override;
-	virtual void Stop() override;
-	virtual bool IsConnected() override;
-	virtual int ReadPacket(uint8_t* buffer, size_t length) override;
+	int Start() override;
+	void Stop() override;
+	bool IsConnected() override;
+	int ReadPacket(uint8_t* buffer, size_t length) override;
 
 private:
 	bool connected;

--- a/Software/Driver/src/samples/driver_HadesVR/include/dataHandler.h
+++ b/Software/Driver/src/samples/driver_HadesVR/include/dataHandler.h
@@ -236,7 +236,7 @@ public:
 private:
 
     void ResetPos(bool hmdOnly);
-	void ReadHIDData();
+	void ReadTransportData();
 	bool connectToPSMOVE();
 	void PSMUpdate();
 
@@ -303,7 +303,7 @@ private:
 	}
 
 	static void ReadHIDEnter(CdataHandler* ptr) {
-		ptr->ReadHIDData();
+		ptr->ReadTransportData();
 	}
 };
 

--- a/Software/Driver/src/samples/driver_HadesVR/include/devices.hpp
+++ b/Software/Driver/src/samples/driver_HadesVR/include/devices.hpp
@@ -30,9 +30,7 @@ THMD HMD;
 TController RightCtrl, LeftCtrl;
 TTracker WaistTrk, LeftTrk, RightTrk;
 
-static CdataHandler dH;
-
-void initDevice(int DeviceType, int DeviceIndex, vr::PropertyContainerHandle_t m_ulPropertyContainer, vr::VRInputComponentHandle_t &haptic, vr::VRInputComponentHandle_t& m_skeletonHandle)
+void initDevice(CdataHandler& dH, int DeviceType, int DeviceIndex, vr::PropertyContainerHandle_t m_ulPropertyContainer, vr::VRInputComponentHandle_t &haptic, vr::VRInputComponentHandle_t& m_skeletonHandle)
 {
 	switch (DeviceType) 
 	{
@@ -288,7 +286,7 @@ void initDevice(int DeviceType, int DeviceIndex, vr::PropertyContainerHandle_t m
 	}
 }
 
-void updateDevice(int DeviceType, int DeviceIndex)
+void updateDevice(CdataHandler& dH, int DeviceType, int DeviceIndex)
 {
 	switch (DeviceType)
 	{
@@ -566,6 +564,7 @@ std::string getDeviceSerial(int type, int index) {
 		}
 		break;
 	}
+	return "Unknown";
 }
 
 

--- a/Software/Driver/src/samples/driver_HadesVR/include/settingsAPIKeys.h
+++ b/Software/Driver/src/samples/driver_HadesVR/include/settingsAPIKeys.h
@@ -52,6 +52,9 @@ static const char* const k_pch_DirectMode_EDID_PID_Int32 = "EDID_PID";
 static const char* const k_pch_DirectMode_EDID_VID_Int32 = "EDID_VID";
 static const char* const k_pch_DirectModeEnable_Bool = "EnableDirectMode";
 
+static const char* const k_pch_TransportMode_String = "TransportMode";
+static const char* const k_pch_UART_Port = "UART_Port";
+static const char* const k_pch_UART_Baudrate = "UART_Baudrate";
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/Software/Driver/src/samples/driver_HadesVR/src/HIDTransport.cpp
+++ b/Software/Driver/src/samples/driver_HadesVR/src/HIDTransport.cpp
@@ -1,0 +1,49 @@
+#include "HIDTransport.hpp"
+#include "driverlog.h"
+#include "hidapi/hidapi.h"
+#include "openvr/openvr_driver.h"
+#include "settingsAPIKeys.h"
+
+int HIDTransport::Start()
+{
+	DriverLog("[HIDTransport] Initializing HID transport");
+
+	if (hid_init() != 0) {
+		DriverLog("[HIDTransport] HID init failed.");
+		return 1;
+	}
+
+	const unsigned short vid = (const unsigned short)vr::VRSettings()->GetInt32(k_pch_Driver_Section, k_pch_HID_PID_Int32);
+	const unsigned short pid = (const unsigned short)vr::VRSettings()->GetInt32(k_pch_Driver_Section, k_pch_HID_VID_Int32);
+	hHID = hid_open((unsigned short)vid, (unsigned short)pid, NULL);
+	if (!hHID) {
+		DriverLog("[HIDTransport] Unable to start data stream of device with pid=%d and vid=%d.\n", pid, vid);
+		HIDConnected = false;
+		return 1;
+	}
+
+	HIDInit = true;
+	HIDConnected = true;
+
+	DriverLog("[DataStream] HID value PID = %d , VID = %d\n", pid, vid);
+
+	return 0;
+}
+
+void HIDTransport::Stop()
+{
+	hid_close(hHID);
+	hid_exit();
+	HIDConnected = false;
+	HIDInit = false;
+}
+
+bool HIDTransport::IsConnected()
+{
+	return HIDConnected;
+}
+
+int HIDTransport::ReadPacket(uint8_t* buffer, size_t length)
+{
+	return hid_read(hHID, buffer, length); //Result should be greater than 0.
+}

--- a/Software/Driver/src/samples/driver_HadesVR/src/HIDTransport.cpp
+++ b/Software/Driver/src/samples/driver_HadesVR/src/HIDTransport.cpp
@@ -13,8 +13,8 @@ int HIDTransport::Start()
 		return 1;
 	}
 
-	const unsigned short vid = (const unsigned short)vr::VRSettings()->GetInt32(k_pch_Driver_Section, k_pch_HID_PID_Int32);
-	const unsigned short pid = (const unsigned short)vr::VRSettings()->GetInt32(k_pch_Driver_Section, k_pch_HID_VID_Int32);
+	const unsigned short pid = (const unsigned short)vr::VRSettings()->GetInt32(k_pch_Driver_Section, k_pch_HID_PID_Int32);
+	const unsigned short vid = (const unsigned short)vr::VRSettings()->GetInt32(k_pch_Driver_Section, k_pch_HID_VID_Int32);
 	hHID = hid_open((unsigned short)vid, (unsigned short)pid, NULL);
 	if (!hHID) {
 		DriverLog("[HIDTransport] Unable to start data stream of device with pid=%d and vid=%d.\n", pid, vid);

--- a/Software/Driver/src/samples/driver_HadesVR/src/UARTTransport.cpp
+++ b/Software/Driver/src/samples/driver_HadesVR/src/UARTTransport.cpp
@@ -1,0 +1,167 @@
+#include <windows.h>
+#include "UARTTransport.hpp"
+#include "driverlog.h"
+#include "settingsAPIKeys.h"
+
+#define FRAME_MAGIC             ((uint8_t)0xAA)
+#define FRAME_HEADER_SIZE       (3u)  // Magic + seqno + size
+
+#define FRAME_MAGIC_INDEX       (0u)
+#define FRAME_SEQNO_INDEX       (1u)
+#define FRAME_DATA_SIZE_INDEX   (2u)
+
+UARTTransport::UARTTransport()
+	: connected(false),
+      lastSeqno(0),
+      hasReceivedFirstFrame(false),
+      hSerial(NULL)
+{
+    ring_buffer_init(&ringbuffer);
+}
+
+int UARTTransport::Start()
+{
+    char portName[16];
+    DWORD baudrate = 230400;
+    vr::EVRSettingsError error;
+
+    vr::VRSettings()->GetString(k_pch_Driver_Section, k_pch_UART_Port, portName, sizeof(portName));
+
+    const int32_t br = vr::VRSettings()->GetInt32(k_pch_Driver_Section, k_pch_UART_Baudrate, &error);
+    if (error == vr::VRSettingsError_None) {
+        baudrate = (DWORD)br;
+    }
+
+    DriverLog("[UARTTransport] Opening serial port %s at %d baud", portName, baudrate);
+    hSerial = CreateFile(("\\\\.\\" + std::string(portName)).c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hSerial == INVALID_HANDLE_VALUE) {
+        DriverLog("[UARTTransport] Error: Could not open serial port.");
+        return 1;
+    }
+
+    dcbSerialParams.DCBlength = sizeof(dcbSerialParams);
+    if (GetCommState(hSerial, &dcbSerialParams) == 0) {
+        DriverLog("[UARTTransport] Error getting device state");
+        CloseHandle(hSerial);
+        return 1;
+    }
+
+    dcbSerialParams.BaudRate = baudrate;
+    dcbSerialParams.ByteSize = 8;
+    dcbSerialParams.StopBits = ONESTOPBIT;
+    dcbSerialParams.Parity = NOPARITY;
+    if (SetCommState(hSerial, &dcbSerialParams) == 0) {
+        DriverLog("[UARTTransport] Error setting device parameters");
+        CloseHandle(hSerial);
+        return 1;
+    }
+
+    timeouts.ReadIntervalTimeout = 50;
+    timeouts.ReadTotalTimeoutConstant = 50;
+    timeouts.ReadTotalTimeoutMultiplier = 10;
+    timeouts.WriteTotalTimeoutConstant = 50;
+    timeouts.WriteTotalTimeoutMultiplier = 10;
+    if (SetCommTimeouts(hSerial, &timeouts) == 0) {
+        DriverLog("[UARTTransport] Error setting timeouts");
+        CloseHandle(hSerial);
+        return 1;
+    }
+
+    DriverLog("[UARTTransport] UART opened successfully");
+
+	connected = true;
+	return 0;
+}
+
+void UARTTransport::Stop()
+{
+    DriverLog("[UARTTransport] Closing serial port...");
+    if (CloseHandle(hSerial) == 0) {
+        DriverLog("[UARTTransport] Error: Could not close serial port.");
+    }
+    else {
+        DriverLog("[UARTTransport] Closed serial port");
+    }
+    connected = false;
+}
+
+bool UARTTransport::IsConnected()
+{
+	return connected;
+}
+
+int UARTTransport::ReadPacket(uint8_t* outBuf, size_t length)
+{
+    DWORD bytesRead = 0;
+    uint8_t tmpBuf[UART_BUFFER_SIZE];
+
+    while (true) {
+        // Fill up the internal ring buffer with data from UART if it's not full (or at least as much data that
+        // is currently available)
+        if (!ring_buffer_is_full(&ringbuffer)) {
+            const DWORD readSize = (DWORD)min(UART_BUFFER_SIZE, UART_BUFFER_SIZE - ring_buffer_num_items(&ringbuffer)) - 1;
+            if (!ReadFile(hSerial, tmpBuf, readSize, &bytesRead, NULL)) {
+                DriverLog("[UARTTransport] Error: Could not read serial port.");
+                return 0;
+            }
+
+            ring_buffer_queue_arr(&ringbuffer, tmpBuf, (ring_buffer_size_t)bytesRead);
+        }
+
+        // All frames start with FRAME_MAGIC, so drop everything until we find it
+        uint8_t magic;
+        while (ring_buffer_peek(&ringbuffer, &magic, FRAME_MAGIC_INDEX)) {
+            if (magic == FRAME_MAGIC) {
+                break;  // We found the magic first in ring buffer
+            }
+
+            // Did not match, just drop this byte
+            ring_buffer_dequeue(&ringbuffer, &magic);
+        }
+
+        // Make sure we have enough data for the header so we can find frame length
+        const ring_buffer_size_t totalSize = ring_buffer_num_items(&ringbuffer);
+        if (totalSize < FRAME_HEADER_SIZE) {
+            break;
+        }
+
+        // Handle frame if we have all data is there
+        uint8_t dataSize = 0u;
+        ring_buffer_peek(&ringbuffer, &dataSize, FRAME_DATA_SIZE_INDEX);
+        if (totalSize >= (FRAME_MAGIC + dataSize)) {
+            // Some logic to log if we miss frames (for debugging performance issues)
+            const uint8_t expectedSeqno = (lastSeqno + 1) & UINT8_MAX;
+            uint8_t currentSeqno;
+            ring_buffer_peek(&ringbuffer, &currentSeqno, FRAME_SEQNO_INDEX);
+
+            if (!hasReceivedFirstFrame) {
+                hasReceivedFirstFrame = true;
+            }
+            else if (currentSeqno != expectedSeqno) {
+                DriverLog("[UARTTransport] Expected seqno 0x%02x, got 0x%02x", expectedSeqno, currentSeqno);
+            }
+
+            lastSeqno = currentSeqno;
+
+            ring_buffer_dequeue_arr(&ringbuffer, outBuf, FRAME_HEADER_SIZE); // Drop header bytes
+            ring_buffer_dequeue_arr(&ringbuffer, outBuf, dataSize);
+
+            // If the received data size does not match the requested one, assume we should fail
+            if (length != dataSize) {
+                DriverLog("[UARTTransport] Warning: Expected %d bytes, got %d bytes", length, dataSize);
+                return 0;
+            }
+
+            return (int)dataSize;
+        }
+
+        // We should never reach this point since data size is one byte (max 256 bytes in payload)
+        // and the ring buffer _should_ be bigger than that. But left here for sake of completeness.
+        if (totalSize == UART_BUFFER_SIZE) {
+            DriverLog("[UARTTransport] Warning: buffer overrun");
+            ring_buffer_init(&ringbuffer);
+        }
+    }
+
+    return 0;
+}

--- a/Software/Driver/src/samples/driver_HadesVR/src/dataHandler.cpp
+++ b/Software/Driver/src/samples/driver_HadesVR/src/dataHandler.cpp
@@ -1,5 +1,10 @@
 #include "dataHandler.h"
 
+CdataHandler::CdataHandler(DataTransport& transport)
+	: dataTransport(transport)
+{
+}
+
 /**
 	 Reads HID data and separates the incoming data packet into HMD, controller or tracker data.
 */
@@ -8,11 +13,9 @@ void CdataHandler::ReadHIDData()
 	HMDQuaternionPacket* DataHMDQuat = (HMDQuaternionPacket*)packet_buffer;
 	HMDRAWPacket* DataHMDRAW = (HMDRAWPacket*)packet_buffer;
 	ControllerPacket* DataCtrl = (ControllerPacket*)packet_buffer;
-	int r;
-	DriverLog("[HID] ReadHIDData Thread created, HIDConnected Status: %d", HIDConnected);
-	while (HIDConnected) {
-		r = hid_read(hHID, packet_buffer, 64); //Result should be greater than 0.
-		if (r > 0) {
+	DriverLog("[HID] ReadHIDData Thread created, HIDConnected Status: %d", dataTransport.IsConnected());
+	while (dataTransport.IsConnected()) {
+		if (dataTransport.ReadPacket(packet_buffer, 64) > 0) {
 			switch (packet_buffer[1])
 			{
 			case 1:		//HMD quaternion packet
@@ -43,7 +46,6 @@ void CdataHandler::ReadHIDData()
 				break;
 
 			case 2:		//Controller quaternion packet
-
 				RightCtrlData.TrackingData.Rotation.W = (float)(DataCtrl->Ctrl1_QuatW) / 32767.f;
 				RightCtrlData.TrackingData.Rotation.X = (float)(DataCtrl->Ctrl1_QuatX) / 32767.f;
 				RightCtrlData.TrackingData.Rotation.Y = (float)(DataCtrl->Ctrl1_QuatY) / 32767.f;
@@ -106,6 +108,7 @@ void CdataHandler::ReadHIDData()
 					HMDfilter.begin();
 					HMDfilter.setBeta(2.f);
 
+
 					if (readsFromInit < 2000) {
 						readsFromInit++;
 					}
@@ -166,6 +169,7 @@ void CdataHandler::ReadHIDData()
 			}
 		}
 	}
+	DriverLog("[HID] Stopping to poll HID data");
 	std::this_thread::sleep_for(std::chrono::milliseconds(1));	//max usb hid update rate is 1000hz.
 }
 
@@ -179,7 +183,7 @@ DriverPose_t CdataHandler::GetHMDPose()
 	pose.qWorldFromDriverRotation = HmdQuaternion_t{ 1, 0, 0, 0 };
 	pose.qDriverFromHeadRotation = HmdQuaternion_t{ 1, 0, 0, 0 };
 
-	if (HIDConnected) {
+	if (dataTransport.IsConnected()) {
 		pose.result = TrackingResult_Running_OK;
 		pose.poseIsValid = true;
 		pose.deviceIsConnected = true;
@@ -264,7 +268,7 @@ DriverPose_t CdataHandler::GetControllersPose(int ControllerIndex)
 {
 	DriverPose_t pose = { 0 };
 
-	if (HIDConnected) {
+	if (dataTransport.IsConnected()) {
 
 		if (receivedControllerData) {
 			pose.poseIsValid = true;
@@ -398,6 +402,7 @@ DriverPose_t CdataHandler::GetControllersPose(int ControllerIndex)
 		}
 		return pose;
 	}
+	return pose;
 }
 
 void CdataHandler::GetControllerData(TController* RightController, TController* LeftController) {
@@ -433,7 +438,7 @@ void CdataHandler::GetControllerData(TController* RightController, TController* 
 */
 void CdataHandler::GetTrackersData(TTracker* waistTracker, TTracker* leftTracker, TTracker* rightTracker)
 {/*
-	if (HIDConnected) {
+	if (dataTransport->IsConnected()) {
 		Quaternion TRKWaistQuat = SetOffsetQuat(TrackerWaistData.Rotation, WaistTrackerOffset, Quaternion::Identity());
 		Quaternion TRKLeftQuat = SetOffsetQuat(TrackerLeftData.Rotation, LeftTrackerOffset, Quaternion::Identity());
 		Quaternion TRKRightQuat = SetOffsetQuat(TrackerRightData.Rotation, RightTrackerOffset, Quaternion::Identity());
@@ -611,23 +616,14 @@ void CdataHandler::PSMUpdate()
 	 Once it does it creates the ReadHID thread and grabs offset calibration data, filter beta, jitter rejection coefficient and PSMS update rate.
 	 Once done it attempts to connect to PSMoveService by calling connectToPSMOVE().
 */
-void CdataHandler::StartData(int32_t PID, int32_t VID)
+void CdataHandler::StartData()
 {
-	if (HIDInit == false) {
-		int result;
-		result = hid_init(); //Result should be 0.
-		if (result) {
-			DriverLog("[DataStream] HID init failed.");
-		}
-
-		hHID = hid_open((unsigned short)VID, (unsigned short)PID, NULL);
-		if (!hHID) {
-			DriverLog("[DataStream] Unable to start data stream of device with pid=%d and vid=%d.\n", PID, VID);
-			HIDConnected = false;
+	if (!dataTransport.IsConnected()) {
+		if (dataTransport.Start() != 0) {
+			DriverLog("[DataStream] Failed to initialize data transport");
 			return;
 		}
-		HIDInit = true;
-		HIDConnected = true;
+
 		pHIDthread = new std::thread(this->ReadHIDEnter, this);
 
 		//get config rotation offsets
@@ -707,8 +703,22 @@ void CdataHandler::StartData(int32_t PID, int32_t VID)
 
 void CdataHandler::StopData() 
 {
-	hid_close(hHID);
-	hid_exit();
-	HIDConnected = false;
-	HIDInit = false;
+	if (dataTransport.IsConnected()) {
+		dataTransport.Stop();
+		if (pHIDthread) {
+			pHIDthread->join();
+			delete pHIDthread;
+			pHIDthread = nullptr;
+		}
+	}
+
+	if (PSMConnected) {
+		PSMConnected = false;
+		PSM_Shutdown();
+		if (pPSMUpdatethread) {
+			pPSMUpdatethread->join();
+			delete pPSMUpdatethread;
+			pPSMUpdatethread = nullptr;
+		}
+	}
 }

--- a/Software/Driver/src/samples/driver_HadesVR/src/dataHandler.cpp
+++ b/Software/Driver/src/samples/driver_HadesVR/src/dataHandler.cpp
@@ -6,14 +6,14 @@ CdataHandler::CdataHandler(DataTransport& transport)
 }
 
 /**
-	 Reads HID data and separates the incoming data packet into HMD, controller or tracker data.
+	 Reads Transport data and separates the incoming data packet into HMD, controller or tracker data.
 */
-void CdataHandler::ReadHIDData()
+void CdataHandler::ReadTransportData()
 {
 	HMDQuaternionPacket* DataHMDQuat = (HMDQuaternionPacket*)packet_buffer;
 	HMDRAWPacket* DataHMDRAW = (HMDRAWPacket*)packet_buffer;
 	ControllerPacket* DataCtrl = (ControllerPacket*)packet_buffer;
-	DriverLog("[HID] ReadHIDData Thread created, HIDConnected Status: %d", dataTransport.IsConnected());
+	DriverLog("[DataTransport] Data transport Thread created, Status: %d", dataTransport.IsConnected());
 	while (dataTransport.IsConnected()) {
 		if (dataTransport.ReadPacket(packet_buffer, 64) > 0) {
 			switch (packet_buffer[1])
@@ -169,7 +169,7 @@ void CdataHandler::ReadHIDData()
 			}
 		}
 	}
-	DriverLog("[HID] Stopping to poll HID data");
+	DriverLog("[DataTransport] Stopping to poll HID data");
 	std::this_thread::sleep_for(std::chrono::milliseconds(1));	//max usb hid update rate is 1000hz.
 }
 

--- a/Software/Driver/src/samples/driver_HadesVR/src/ringbuffer.c
+++ b/Software/Driver/src/samples/driver_HadesVR/src/ringbuffer.c
@@ -1,0 +1,83 @@
+// Note: Implementation comes from here:
+// https://github.com/AndersKaloer/Ring-Buffer
+//
+// Modifications made here:
+// * RING_BUFFER_SIZE changed from 128 to 512
+// * ring_buffer_size_t changed to uint16_t
+// * Use ring_buffer_data_t (uint8_t) as item type (instead of char)
+
+#include "ringbuffer.h"
+
+/**
+ * @file
+ * Implementation of ring buffer functions.
+ */
+
+void ring_buffer_init(ring_buffer_t *buffer) {
+  buffer->tail_index = 0;
+  buffer->head_index = 0;
+}
+
+void ring_buffer_queue(ring_buffer_t *buffer, ring_buffer_data_t data) {
+  /* Is buffer full? */
+  if(ring_buffer_is_full(buffer)) {
+    /* Is going to overwrite the oldest byte */
+    /* Increase tail index */
+    buffer->tail_index = ((buffer->tail_index + 1) & RING_BUFFER_MASK);
+  }
+
+  /* Place data in buffer */
+  buffer->buffer[buffer->head_index] = data;
+  buffer->head_index = ((buffer->head_index + 1) & RING_BUFFER_MASK);
+}
+
+void ring_buffer_queue_arr(ring_buffer_t *buffer, const ring_buffer_data_t*data, ring_buffer_size_t size) {
+  /* Add bytes; one by one */
+  ring_buffer_size_t i;
+  for(i = 0; i < size; i++) {
+    ring_buffer_queue(buffer, data[i]);
+  }
+}
+
+uint8_t ring_buffer_dequeue(ring_buffer_t *buffer, ring_buffer_data_t*data) {
+  if(ring_buffer_is_empty(buffer)) {
+    /* No items */
+    return 0;
+  }
+
+  *data = buffer->buffer[buffer->tail_index];
+  buffer->tail_index = ((buffer->tail_index + 1) & RING_BUFFER_MASK);
+  return 1;
+}
+
+ring_buffer_size_t ring_buffer_dequeue_arr(ring_buffer_t *buffer, ring_buffer_data_t *data, ring_buffer_size_t len) {
+  if(ring_buffer_is_empty(buffer)) {
+    /* No items */
+    return 0;
+  }
+
+  char *data_ptr = data;
+  ring_buffer_size_t cnt = 0;
+  while((cnt < len) && ring_buffer_dequeue(buffer, data_ptr)) {
+    cnt++;
+    data_ptr++;
+  }
+  return cnt;
+}
+
+uint8_t ring_buffer_peek(ring_buffer_t *buffer, ring_buffer_data_t *data, ring_buffer_size_t index) {
+  if(index >= ring_buffer_num_items(buffer)) {
+    /* No items at index */
+    return 0;
+  }
+
+  /* Add index to pointer */
+  ring_buffer_size_t data_index = ((buffer->tail_index + index) & RING_BUFFER_MASK);
+  *data = buffer->buffer[data_index];
+  return 1;
+}
+
+extern inline uint8_t ring_buffer_is_empty(ring_buffer_t *buffer);
+extern inline uint8_t ring_buffer_is_full(ring_buffer_t *buffer);
+extern inline ring_buffer_size_t ring_buffer_num_items(ring_buffer_t *buffer);
+

--- a/Software/Driver/src/samples/driver_HadesVR/src/ringbuffer.h
+++ b/Software/Driver/src/samples/driver_HadesVR/src/ringbuffer.h
@@ -1,0 +1,147 @@
+#include <inttypes.h>
+
+/**
+ * @file
+ * Prototypes and structures for the ring buffer module.
+ */
+
+#ifndef RINGBUFFER_H
+#define RINGBUFFER_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * The size of a ring buffer.
+ * Due to the design only <tt> RING_BUFFER_SIZE-1 </tt> items
+ * can be contained in the buffer.
+ * The buffer size must be a power of two.
+*/
+#define RING_BUFFER_SIZE 512
+
+#if (RING_BUFFER_SIZE & (RING_BUFFER_SIZE - 1)) != 0
+#error "RING_BUFFER_SIZE must be a power of two"
+#endif
+
+/**
+ * The type which is used to hold the size
+ * and the indicies of the buffer.
+ * Must be able to fit \c RING_BUFFER_SIZE .
+ */
+typedef uint16_t ring_buffer_size_t;
+
+/**
+ * The type used for stored items.
+ */
+typedef uint8_t ring_buffer_data_t;
+
+
+/**
+ * Used as a modulo operator
+ * as <tt> a % b = (a & (b − 1)) </tt>
+ * where \c a is a positive index in the buffer and
+ * \c b is the (power of two) size of the buffer.
+ */
+#define RING_BUFFER_MASK (RING_BUFFER_SIZE-1)
+
+/**
+ * Simplifies the use of <tt>struct ring_buffer_t</tt>.
+ */
+typedef struct ring_buffer_t ring_buffer_t;
+
+/**
+ * Structure which holds a ring buffer.
+ * The buffer contains a buffer array
+ * as well as metadata for the ring buffer.
+ */
+struct ring_buffer_t {
+  /** Buffer memory. */
+  char buffer[RING_BUFFER_SIZE];
+  /** Index of tail. */
+  ring_buffer_size_t tail_index;
+  /** Index of head. */
+  ring_buffer_size_t head_index;
+};
+
+/**
+ * Initializes the ring buffer pointed to by <em>buffer</em>.
+ * This function can also be used to empty/reset the buffer.
+ * @param buffer The ring buffer to initialize.
+ */
+void ring_buffer_init(ring_buffer_t *buffer);
+
+/**
+ * Adds a byte to a ring buffer.
+ * @param buffer The buffer in which the data should be placed.
+ * @param data The byte to place.
+ */
+void ring_buffer_queue(ring_buffer_t *buffer, ring_buffer_data_t data);
+
+/**
+ * Adds an array of bytes to a ring buffer.
+ * @param buffer The buffer in which the data should be placed.
+ * @param data A pointer to the array of bytes to place in the queue.
+ * @param size The size of the array.
+ */
+void ring_buffer_queue_arr(ring_buffer_t *buffer, const ring_buffer_data_t*data, ring_buffer_size_t size);
+
+/**
+ * Returns the oldest byte in a ring buffer.
+ * @param buffer The buffer from which the data should be returned.
+ * @param data A pointer to the location at which the data should be placed.
+ * @return 1 if data was returned; 0 otherwise.
+ */
+uint8_t ring_buffer_dequeue(ring_buffer_t *buffer, ring_buffer_data_t*data);
+
+/**
+ * Returns the <em>len</em> oldest bytes in a ring buffer.
+ * @param buffer The buffer from which the data should be returned.
+ * @param data A pointer to the array at which the data should be placed.
+ * @param len The maximum number of bytes to return.
+ * @return The number of bytes returned.
+ */
+ring_buffer_size_t ring_buffer_dequeue_arr(ring_buffer_t *buffer, ring_buffer_data_t *data, ring_buffer_size_t len);
+/**
+ * Peeks a ring buffer, i.e. returns an element without removing it.
+ * @param buffer The buffer from which the data should be returned.
+ * @param data A pointer to the location at which the data should be placed.
+ * @param index The index to peek.
+ * @return 1 if data was returned; 0 otherwise.
+ */
+uint8_t ring_buffer_peek(ring_buffer_t *buffer, ring_buffer_data_t *data, ring_buffer_size_t index);
+
+
+/**
+ * Returns whether a ring buffer is empty.
+ * @param buffer The buffer for which it should be returned whether it is empty.
+ * @return 1 if empty; 0 otherwise.
+ */
+inline uint8_t ring_buffer_is_empty(ring_buffer_t *buffer) {
+  return (buffer->head_index == buffer->tail_index);
+}
+
+/**
+ * Returns whether a ring buffer is full.
+ * @param buffer The buffer for which it should be returned whether it is full.
+ * @return 1 if full; 0 otherwise.
+ */
+inline uint8_t ring_buffer_is_full(ring_buffer_t *buffer) {
+  return ((buffer->head_index - buffer->tail_index) & RING_BUFFER_MASK) == RING_BUFFER_MASK;
+}
+
+/**
+ * Returns the number of items in a ring buffer.
+ * @param buffer The buffer for which the number of items should be returned.
+ * @return The number of items in the ring buffer.
+ */
+inline ring_buffer_size_t ring_buffer_num_items(ring_buffer_t *buffer) {
+  return ((buffer->head_index - buffer->tail_index) & RING_BUFFER_MASK);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RINGBUFFER_H */

--- a/docs/Driver.md
+++ b/docs/Driver.md
@@ -21,11 +21,24 @@ The driver configuration is divided into a couple sections for tidyness, these a
 ### "Driver" section where you'll find:
 |Parameter|Type    |Description|
 | ------  | ------ |------     |
-| HID_VID | int | The VID value of your HID device, in decimal numbers. |
-| HID_PID | int | The PID value of your HID device, in decimal numbers. |
+| TransportMode | string | Either HID or UART depending on how HMD is connected, see below. |
 | PSMSTrackerFrequency | int | The maximum update rate you have set on your psmoveservice trackers.|
 | ControllerSmoothingK | float | K constant of the controller position smoothing algorithm |
 | HMDSmoothingK | float | K constant of the HMD position smoothing algorithm |
+
+If `TransportMode` is set to `HID` (or left unset):
+
+|Parameter|Type    |Description|
+| ------  | ------ |------     |
+| HID_VID | int | The VID value of your HID device, in decimal numbers. |
+| HID_PID | int | The PID value of your HID device, in decimal numbers. |
+
+If `TransportMode` is set to `UART`:
+
+|Parameter|Type    |Description|
+| ------  | ------ |------     |
+| UART_Port | string | UART port name HMD is connected to, e.g. COM3. |
+| UART_Baudrate | int | Baudrate used for UART communication, e.g. 115200 or 230400. |
 
 ### "Display" section where you'll find:
 |Parameter|Type    |Description|


### PR DESCRIPTION
This PR introduces support for receiving data from the HMD over UART instead of HID in the Steam VR driver. The driver uses HID by default but can be switched over to UART by setting `TransportMode` to `UART` in the configuration. The headset firmware (non-DMP version) has been modified to support UART via a compile-time configuration setting.

The "protocol" used over UART uses a simple frame format like this:

| Magic (0xAA) | Sequence number (1 byte) | Size (1 byte) | HID Data ("size" bytes) |
| --- | --- | --- | --- |

The same HID payload as is carried in the HID transport is also carried here, so there's no need for converting data between different formats. It's just a different way to transfer it. CRC8 can (and probably should) be added at a later time for better protection against errors.

Most people probably don't need this, but it opens up for other microcontrollers to be used that do not support HID. I use the RF-Nano for instance (which is an Arduino Nano with built in NRF24L01 radio). Bandwidth over the UART might be lower than over USB HID, might be worth noting.